### PR TITLE
BankApp-4: fix for removed preview assets

### DIFF
--- a/BankApp/BankApp.xcodeproj/project.pbxproj
+++ b/BankApp/BankApp.xcodeproj/project.pbxproj
@@ -610,7 +610,7 @@
 				CODE_SIGN_ENTITLEMENTS = BankApp/Resources/BankApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "\"BankApp/Preview Content\"";
+				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -648,7 +648,7 @@
 				CODE_SIGN_ENTITLEMENTS = BankApp/Resources/BankApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "\"BankApp/Preview Content\"";
+				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;


### PR DESCRIPTION
## 📌 References
- Jira task: BankApp-4

## 🥅 What is the goal?
Fix the app failing to compile.

## 👷 How has it been solved?
Removed Preview content from DEVELOPMENT_ASSET_PATHS.